### PR TITLE
Feat(SRE-378): add default capacity provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -211,6 +211,64 @@ resource "aws_autoscaling_group" "container_instance" {
   }
 }
 
+resource "aws_launch_configuration" "container_instance" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  root_block_device {
+    volume_type = "${var.root_block_device_type}"
+    volume_size = "${var.root_block_device_size}"
+  }
+
+  name_prefix          = "lc${title(var.environment)}ContainerInstance-"
+  iam_instance_profile = "${aws_iam_instance_profile.container_instance.name}"
+
+  # Using join() is a workaround for depending on conditional resources.
+  # https://github.com/hashicorp/terraform/issues/2831#issuecomment-298751019
+  image_id = "${var.lookup_latest_ami ? join("", data.aws_ami.ecs_ami.*.image_id) : join("", data.aws_ami.user_ami.*.image_id)}"
+
+  instance_type   = "${var.instance_type}"
+  key_name        = "${var.key_name}"
+  security_groups = ["${aws_security_group.container_instance.id}"]
+  user_data       = "${data.template_cloudinit_config.container_instance_cloud_config.rendered}"
+}
+
+resource "aws_autoscaling_group" "container_instance" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  name                      = "asg${title(var.environment)}ContainerInstance"
+  launch_configuration      = "${aws_launch_configuration.container_instance.name}"
+  health_check_grace_period = "${var.health_check_grace_period}"
+  health_check_type         = "EC2"
+  desired_capacity          = "${var.desired_capacity}"
+  termination_policies      = ["OldestLaunchConfiguration", "Default"]
+  min_size                  = "${var.min_size}"
+  max_size                  = "${var.max_size}"
+  enabled_metrics           = ["${var.enabled_metrics}"]
+  vpc_zone_identifier       = ["${var.private_subnet_ids}"]
+
+  tag {
+    key                 = "Name"
+    value               = "ContainerInstance"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Project"
+    value               = "${var.project}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = "${var.environment}"
+    propagate_at_launch = true
+  }
+}
+
 #
 # ECS resources
 #

--- a/main.tf
+++ b/main.tf
@@ -211,7 +211,7 @@ resource "aws_autoscaling_group" "container_instance" {
   }
 }
 
-resource "aws_launch_configuration" "container_instance" {
+resource "aws_launch_configuration" "container_instance_scheduled_tasks" {
   lifecycle {
     create_before_destroy = true
   }
@@ -221,38 +221,38 @@ resource "aws_launch_configuration" "container_instance" {
     volume_size = "${var.root_block_device_size}"
   }
 
-  name_prefix          = "lc${title(var.environment)}ContainerInstance-"
+  name_prefix          = "lc${title(var.environment)}ContainerInstanceScheduledTasks-"
   iam_instance_profile = "${aws_iam_instance_profile.container_instance.name}"
 
   # Using join() is a workaround for depending on conditional resources.
   # https://github.com/hashicorp/terraform/issues/2831#issuecomment-298751019
   image_id = "${var.lookup_latest_ami ? join("", data.aws_ami.ecs_ami.*.image_id) : join("", data.aws_ami.user_ami.*.image_id)}"
 
-  instance_type   = "${var.instance_type}"
+  instance_type   = "${var.instance_type_scheduled_tasks}"
   key_name        = "${var.key_name}"
   security_groups = ["${aws_security_group.container_instance.id}"]
   user_data       = "${data.template_cloudinit_config.container_instance_cloud_config.rendered}"
 }
 
-resource "aws_autoscaling_group" "container_instance" {
+resource "aws_autoscaling_group" "container_instance_scheduled_tasks" {
   lifecycle {
     create_before_destroy = true
   }
 
-  name                      = "asg${title(var.environment)}ContainerInstance"
-  launch_configuration      = "${aws_launch_configuration.container_instance.name}"
+  name                      = "asg${title(var.environment)}ContainerInstanceScheduledTasks"
+  launch_configuration      = "${aws_launch_configuration.container_instance_scheduled_tasks.name}"
   health_check_grace_period = "${var.health_check_grace_period}"
   health_check_type         = "EC2"
-  desired_capacity          = "${var.desired_capacity}"
+  desired_capacity          = "${var.desired_capacity_scheduled_tasks}"
   termination_policies      = ["OldestLaunchConfiguration", "Default"]
-  min_size                  = "${var.min_size}"
-  max_size                  = "${var.max_size}"
+  min_size                  = "${var.min_size_scheduled_tasks}"
+  max_size                  = "${var.max_size_scheduled_tasks}"
   enabled_metrics           = ["${var.enabled_metrics}"]
   vpc_zone_identifier       = ["${var.private_subnet_ids}"]
 
   tag {
     key                 = "Name"
-    value               = "ContainerInstance"
+    value               = "ContainerInstanceScheduledTasks"
     propagate_at_launch = true
   }
 
@@ -274,6 +274,22 @@ resource "aws_autoscaling_group" "container_instance" {
 #
 resource "aws_ecs_cluster" "container_instance" {
   name = "ecs${title(var.environment)}Cluster"
+  capacity_providers = [aws_ecs_capacity_provider.scheduled_tasks.name]
+  default_capacty_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.scheduled_tasks.name
+  }
+}
+
+resource "aws_ecs_capacity_provider" "scheduled_tasks" {
+  name = "scheduled_tasks"
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.container_instance_scheduled_tasks.arn
+    managed_scaling {
+      status = "ENABLED"
+      target_capacity = 100
+    }
+    managed_termination_protection = false
+  }
 }
 
 #

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,8 +22,8 @@ output "ecs_autoscale_role_name" {
   value = "${aws_iam_role.ecs_autoscale_role.name}"
 }
 
-output "container_instance_autoscaling_group_name" {
-  value = "${aws_autoscaling_group.container_instance.name}"
+output "container_instance_autoscaling_group_name_scheduled_tasks" {
+  value = "${aws_autoscaling_group.container_instance_scheduled_tasks.name}"
 }
 
 output "ecs_service_role_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,10 @@ variable "instance_type" {
   default = "t2.micro"
 }
 
+variable "instance_type_scheduled_tasks" {
+  default = "m5.4xlarge"
+}
+
 variable "key_name" {}
 
 variable "cloud_config_content" {}
@@ -48,8 +52,20 @@ variable "desired_capacity" {
   default = "1"
 }
 
+variable "desired_capacity_scheduled_tasks" {
+  default = "0"
+}
+
 variable "min_size" {
   default = "1"
+}
+
+variable "max_size_scheduled_tasks" {
+  default = "10"
+}
+
+variable "min_size_scheduled_tasks {
+  default = "0"
 }
 
 variable "max_size" {


### PR DESCRIPTION
This includes a new ASG to be used with a capacity provider when running scheduled tasks. This is not to be used for general services and tasks, since they have a mix of placement strategies that doesn't work well with a capacity provider at the moment. All services and tasks should continue to use the `EC2` launch type.

This enables https://github.com/builtinx/infrastructure/pull/907