### PR TITLE
feat(SRE-378): use locals for cluster name

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -4,5 +4,6 @@ locals {
   autoscaling_group_name_scheduled_tasks = "asg${title(var.environment)}ContainerInstanceScheduledTasks"
   security_group_name                    = "sgContainerInstance"
   ecs_for_ec2_service_role_name          = "${var.environment}ContainerInstanceProfile"
+  ecs_cluster_name                       = coalesce(var.cluster_name, local.cluster_name)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ data "template_file" "container_instance_base_cloud_config" {
   )
 
   vars = {
-    ecs_cluster_name = aws_ecs_cluster.container_instance.name
+    ecs_cluster_name = local.ecs_cluster_name
   }
 }
 
@@ -306,7 +306,7 @@ resource "aws_autoscaling_group" "container_instance_scheduled_tasks" {
 # ECS resources
 #
 resource "aws_ecs_cluster" "container_instance" {
-  name               = coalesce(var.cluster_name, local.cluster_name)
+  name               = local.ecs_cluster_name
   capacity_providers = [aws_ecs_capacity_provider.scheduled_tasks.name]
   default_capacty_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.scheduled_tasks.name


### PR DESCRIPTION
This fixes a circular dependency problem.